### PR TITLE
initial openocd support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@ Video of work: https://youtu.be/M7RBQsq5_lc
 3) cmake
 4) clang
 5) st-link https://github.com/texane/stlink
+6) (optional) openocd
 //5) https://github.com/SL-RU/STM32CubeMX_cmake
 
 ### Install:
@@ -19,9 +20,11 @@ Video of work: https://youtu.be/M7RBQsq5_lc
 4) add to your init file (require 'stm32)
 5) install cmake-ide and [configure](https://syamajala.github.io/c-ide.html)
 
-### Commentary:
+### How to use:
 
 WORK IN PROGRESS!!!
+
+#### GDB and st-link
 1) Create STM32CubeMx project and generate it for SW4STM32
 2) M-x stm32-new-project RET *select CubeMX project path*
 3) open main.c
@@ -31,6 +34,26 @@ WORK IN PROGRESS!!!
 7) start GDB debugger with stm32-start-gdb
 8) in gdb) "load" to upload file to MC and "cont" to run.For more see https://github.com/texane/stlink
 9) good luck!
+
+#### Openocd
+
+Openocd requieres a .cfg file to properly function you need to provide the file in this case it must be
+called board.cfg, and example file is provided (board.cfg) the file needs to be located in your project root.
+
+##### FreeRTOS support
+
+Openocd can
+
+1) Create STM32CubeMx project and generate it for SW4STM32
+2) M-x stm32-new-project RET *select CubeMX project path*
+3) put the board.cfg in your proyect root(an example file named board.cfg is provided in this repo)
+3) open main.c
+4) C-c . C to compile
+5) connect stlink to your PC
+6) stm32-run-openocd to start openocd server
+7) start GDB debugger with stm32-start-openocd-gdb
+
+after this you shold be in the debugger window and you can debug your program, but the default gdb window acts like a terminal and is not very helpful in regards of context and data, so its a good idea to use gdb in many windows mode you can acativate it in your startup config file or with M-x gdb-many-windows
 
 
 After CubeMx project regeneration or adding new libraries or new sources you need to do M-x stm32-cmake-build
@@ -43,5 +66,5 @@ If you have error in cmsis_gcc.h do ```M-x stm32-fix-vfpcc```. It will change so
 # License:
 
 This program is distributed under the terms of GNU General
-Public License, version 3 or any later version. See COPYING 
+Public License, version 3 or any later version. See COPYING
 for details.

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
+
 Some functions for work with stm32 arm microcontrollers in EMACS.
 
 Video of work: https://youtu.be/M7RBQsq5_lc
@@ -25,7 +27,7 @@ Video of work: https://youtu.be/M7RBQsq5_lc
 
 WORK IN PROGRESS!!!
 
-#### GDB and st-link
+  #### GDB and st-link
 1) Create STM32CubeMx project and generate it for SW4STM32
 2) M-x stm32-new-project RET *select CubeMX project path*
 3) open main.c
@@ -36,7 +38,7 @@ WORK IN PROGRESS!!!
 8) in gdb) "load" to upload file to MC and "cont" to run.For more see https://github.com/texane/stlink
 9) good luck!
 
-#### GDB and Openocd
+  #### GDB and Openocd
 
 Openocd requieres a .cfg file to properly function you need to provide the file in this case it must be
 called board.cfg, and example file is provided (board.cfg) the file needs to be located in your project root.
@@ -52,16 +54,16 @@ called board.cfg, and example file is provided (board.cfg) the file needs to be 
 8) debug your project and good luck!
 
 
-after this you shold be in the debugger window and you can debug your program, but the default gdb window acts like a terminal and is not very helpful in regards of context and data, so its a good idea to use gdb in many windows mode you can acativate it in your startup config file or with M-x gdb-many-windows
+After this you shold be in the debugger window and you can debug your program, but the default gdb window acts like a terminal and is not very helpful in regards of context and data, so its a good idea to use gdb in many windows mode you can acativate it in your startup config file or with M-x gdb-many-windows
 
 ### Compilation funcitions
 
-you can build or clean and build your projects
+You can build or clean and build your projects with the following functions.
 
-- stm32-cmake-build:
+- 'stm32-cmake-build
   this is the equivalent of cleand and build of most IDE's and it recompiles every source file of your project
 
-- stm32-make-build:
+- 'stm32-make-build
   the equivalent of build of most IDE's with this you can compile only the modified source files of your project scince the last compilation, this is useful if you only changed a couple of lines in your project as it makes the compilation proces faster.
 
 ### Closing stm32-debugger

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ WORK IN PROGRESS!!!
 8) in gdb) "load" to upload file to MC and "cont" to run.For more see https://github.com/texane/stlink
 9) good luck!
 
-**NOTE**: The step 6 can be omited as the step 7 cheks if `st-util` is running and starts it if it's not running, but it is recommended the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
+**NOTE**: The step 6 can be omited as the step 7 cheks if `st-util` is running and starts it if it's not running, but it is recommended the first time to run the steps one by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
 
 ### GDB and Openocd
 ***
@@ -59,7 +59,7 @@ called board.cfg, and example file is provided (board.cfg) the file needs to be 
 7) start GDB debugger with <kbd>M-x</kbd>`stm32-start-openocd-gdb`<kbd>[RET]</kbd>
 8) debug your project and good luck!
 
-**NOTE**: The step 6 can be omited as the step 7 cheks if `openocd` is running and starts it if it's not running, but it is recommended the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
+**NOTE**: The step 6 can be omited as the step 7 cheks if `openocd` is running and starts it if it's not running, but it is recommended the first time to run the steps one by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
 
 #### RTOS support
 ***

--- a/Readme.md
+++ b/Readme.md
@@ -60,16 +60,16 @@ After this you shold be in the debugger window and you can debug your program, b
 
 You can build or clean and build your projects with the following functions.
 
-- `stm32-cmake-build
+- `stm32-cmake-build`
   this is the equivalent of cleand and build of most IDE's and it recompiles every source file of your project
 
-- `stm32-make-build
+- `stm32-make-build`
   the equivalent of build of most IDE's with this you can compile only the modified source files of your project scince the last compilation, this is useful if you only changed a couple of lines in your project as it makes the compilation proces faster.
 
 ### Closing stm32-debugger
 Once you finished your debugin session you can finish all the windows opened by this plugin with the following function.
 
-`stm32-kill-gdb
+`stm32-kill-gdb`
 
 This will kill the gdb process and the st-link or openocd proces depending on which do you chose to run
 

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ WORK IN PROGRESS!!!
 8) in gdb) "load" to upload file to MC and "cont" to run.For more see https://github.com/texane/stlink
 9) good luck!
 
-**NOTE**: The step 6 can be omited as the step 7 cheks if `st-util` is running and starts it if it's not running, but it is recommended to run the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
+**NOTE**: The step 6 can be omited as the step 7 cheks if `st-util` is running and starts it if it's not running, but it is recommended the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
 
 ### GDB and Openocd
 ***
@@ -59,7 +59,7 @@ called board.cfg, and example file is provided (board.cfg) the file needs to be 
 7) start GDB debugger with <kbd>M-x</kbd>`stm32-start-openocd-gdb`<kbd>[RET]</kbd>
 8) debug your project and good luck!
 
-**NOTE**: The step 6 can be omited as the step 7 cheks if `openocd` is running and starts it if it's not running, but it is recommended to run the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
+**NOTE**: The step 6 can be omited as the step 7 cheks if `openocd` is running and starts it if it's not running, but it is recommended the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
 
 #### RTOS support
 ***

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
+[![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
 
 Some functions for work with stm32 arm microcontrollers in EMACS.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-#STM32-Emacs
+# STM32-Emacs
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
 
 Some functions for work with stm32 arm microcontrollers in EMACS.

--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,7 @@ Video of work: https://youtu.be/M7RBQsq5_lc
 4) clang
 5) st-link https://github.com/texane/stlink
 6) (optional) openocd
+
 //5) https://github.com/SL-RU/STM32CubeMX_cmake
 
 ### Install:
@@ -35,26 +36,38 @@ WORK IN PROGRESS!!!
 8) in gdb) "load" to upload file to MC and "cont" to run.For more see https://github.com/texane/stlink
 9) good luck!
 
-#### Openocd
+#### GDB and Openocd
 
 Openocd requieres a .cfg file to properly function you need to provide the file in this case it must be
 called board.cfg, and example file is provided (board.cfg) the file needs to be located in your project root.
 
-##### FreeRTOS support
-
-Openocd can
-
 1) Create STM32CubeMx project and generate it for SW4STM32
 2) M-x stm32-new-project RET *select CubeMX project path*
-3) put the board.cfg in your proyect root(an example file named board.cfg is provided in this repo)
+3) put the board.cfg in your project root(an example file named board.cfg is provided in this repo)
 3) open main.c
 4) C-c . C to compile
 5) connect stlink to your PC
 6) stm32-run-openocd to start openocd server
 7) start GDB debugger with stm32-start-openocd-gdb
+8) debug your project and good luck!
+
 
 after this you shold be in the debugger window and you can debug your program, but the default gdb window acts like a terminal and is not very helpful in regards of context and data, so its a good idea to use gdb in many windows mode you can acativate it in your startup config file or with M-x gdb-many-windows
 
+### Compilation funcitions
+
+you can build or clean and build your projects
+
+- stm32-cmake-build:
+  this is the equivalent of cleand and build of most IDE's and it recompiles every source file of your project
+
+- stm32-make-build:
+  the equivalent of build of most IDE's with this you can compile only the modified source files of your project scince the last compilation, this is useful if you only changed a couple of lines in your project as it makes the compilation proces faster.
+
+### Closing stm32-debugger
+Once you finished your debugin session you can finish all the windows opened by this plugin with the following function.
+
+- M-x stm32-kill-gdb
 
 After CubeMx project regeneration or adding new libraries or new sources you need to do M-x stm32-cmake-build
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,76 +1,91 @@
 # STM32-Emacs
-[![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
+***
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 Some functions for work with stm32 arm microcontrollers in EMACS.
 
 Video of work: https://youtu.be/M7RBQsq5_lc
 
-### Required:
+## Required:
+***
+- cmake-ide
+- python
+- cmake
+- clang
+- st-link https://github.com/texane/stlink
+- https://github.com/SL-RU/STM32CubeMX_cmake
+- (optional) openocd
 
-1) cmake-ide
-2) python
-3) cmake
-4) clang
-5) st-link https://github.com/texane/stlink
-6) (optional) openocd
 
-//5) https://github.com/SL-RU/STM32CubeMX_cmake
-
-### Install:
-
+## Install:
+***
 1) clone repository to /.emacs.d/stm32
 2) execute "git submodule update --init" to clone STM32CubeMX_cmake to /.emacs.d/stm32/STM32CubeMX_cmake
 3) Change paths to yours in stm32.el
 4) add to your init file (require 'stm32)
 5) install cmake-ide and [configure](https://syamajala.github.io/c-ide.html)
 
-### How to use:
-
+## How to use:
+***
 WORK IN PROGRESS!!!
+`STM32-Emacs` can use two diferent tools for debuggin
 
-  #### GDB and st-link
+### GDB and st-link
+***  
 1) Create STM32CubeMx project and generate it for SW4STM32
-2) M-x stm32-new-project RET *select CubeMX project path*
+2) <kbd>M-x</kbd>`stm32-new-project`<kbd>[RET]</kbd>*select CubeMX project path*
 3) open main.c
-4) C-c . C to compile
+4) C-c . C or <kbd>M-x</kbd>`stm32-cmake-build`<kbd>[RET]</kbd> to compile
 5) connect stlink to your PC
-6) stm32-run-st-util to start gdb server
-7) start GDB debugger with stm32-start-gdb
+6) <kbd>M-x</kbd>`stm32-run-st-util`<kbd>[RET]</kbd> to start gdb server
+7) start GDB debugger with <kbd>M-x</kbd>`stm32-start-gdb`<kbd>[RET]</kbd>
 8) in gdb) "load" to upload file to MC and "cont" to run.For more see https://github.com/texane/stlink
 9) good luck!
 
-  #### GDB and Openocd
+**NOTE**: The step 6 can be omited as the step 7 cheks if `st-util` is running and starts it if it's not running, but it is recommended to run the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
 
+### GDB and Openocd
+***
 Openocd requieres a .cfg file to properly function you need to provide the file in this case it must be
 called board.cfg, and example file is provided (board.cfg) the file needs to be located in your project root.
 
 1) Create STM32CubeMx project and generate it for SW4STM32
-2) M-x stm32-new-project RET *select CubeMX project path*
+2) <kbd>M-x</kbd>`stm32-new-project`<kbd>[RET]</kbd> *select CubeMX project path*
 3) put the board.cfg in your project root(an example file named board.cfg is provided in this repo)
 3) open main.c
-4) C-c . C to compile
+4) C-c . C or <kbd>M-x</kbd>`stm32-cmake-build`<kbd>[RET]</kbd> to compile
 5) connect stlink to your PC
-6) stm32-run-openocd to start openocd server
-7) start GDB debugger with stm32-start-openocd-gdb
+6) <kbd>M-x</kbd>`stm32-run-openocd`<kbd>[RET]</kbd> to start openocd server
+7) start GDB debugger with <kbd>M-x</kbd>`stm32-start-openocd-gdb`<kbd>[RET]</kbd>
 8) debug your project and good luck!
 
+**NOTE**: The step 6 can be omited as the step 7 cheks if `openocd` is running and starts it if it's not running, but it is recommended to run the first time to run the steps on by one in case of configuration errors, once you are in the debug window you can skip step 6 in the next debugging sessions.
 
-After this you shold be in the debugger window and you can debug your program, but the default gdb window acts like a terminal and is not very helpful in regards of context and data, so its a good idea to use gdb in many windows mode you can acativate it in your startup config file or with M-x gdb-many-windows
+#### RTOS support
+***
+If you have a project using an RTOS (FreeRTOS for example) you can debug your project without problems but only openocd [supports](http://openocd.org/doc/html/GDB-and-OpenOCD.html) debugging tasks or threads, this is because openocd searches the tasks of your project and presents them as threads to gdb with this you can wath the stack of every task and also the current state of the task, in order to do this you need to follow the next steps.
+
+#TODO document the necesary changes of CmakeLists file
+
+### Optional gdb steps
+***
+Once you are in the debuger window you can load and test your prject, but the default gdb window acts like a terminal and is not very helpful in regards of context and data, so its a good idea to use gdb in many windows mode you can activate it in your startup config file with `(gdb-many-windows 1)` or with <kbd>M-x</kbd> gdb-many-windows <kbd>[RET]</kbd>
 
 ### Compilation funcitions
-
+***
 You can build or clean and build your projects with the following functions.
 
-- `stm32-cmake-build`
+- <kbd>M-x</kbd>`stm32-cmake-build` <kbd>[RET]</kbd>
   this is the equivalent of cleand and build of most IDE's and it recompiles every source file of your project
 
-- `stm32-make-build`
+- <kbd>M-x</kbd>`stm32-make-build` <kbd>[RET]</kbd>
   the equivalent of build of most IDE's with this you can compile only the modified source files of your project scince the last compilation, this is useful if you only changed a couple of lines in your project as it makes the compilation proces faster.
 
 ### Closing stm32-debugger
-Once you finished your debugin session you can finish all the windows opened by this plugin with the following function.
+***
+Once you finished your debugging session you can finish all the windows opened by this plugin with the following function.
 
-`stm32-kill-gdb`
+<kbd>M-x</kbd> `stm32-kill-gdb` <kbd>[RET]</kbd>
 
 This will kill the gdb process and the st-link or openocd proces depending on which do you chose to run
 
@@ -78,11 +93,11 @@ After CubeMx project regeneration or adding new libraries or new sources you nee
 
 
 # IMPORTANT
-
-If you have error in cmsis_gcc.h do ```M-x stm32-fix-vfpcc```. It will change some lines in cmsis_gcc.h and will create backup cmsis_gcc.h.bak.
+***
+If you have error in cmsis_gcc.h do <kbd>M-x</kbd>`M-x stm32-fix-vfpcc`<kbd>[RET]</kbd>. It will change some lines in cmsis_gcc.h and will create backup cmsis_gcc.h.bak.
 
 # License:
-
+***
 This program is distributed under the terms of GNU General
 Public License, version 3 or any later version. See COPYING
 for details.

--- a/Readme.md
+++ b/Readme.md
@@ -60,16 +60,18 @@ After this you shold be in the debugger window and you can debug your program, b
 
 You can build or clean and build your projects with the following functions.
 
-- 'stm32-cmake-build
+- `stm32-cmake-build
   this is the equivalent of cleand and build of most IDE's and it recompiles every source file of your project
 
-- 'stm32-make-build
+- `stm32-make-build
   the equivalent of build of most IDE's with this you can compile only the modified source files of your project scince the last compilation, this is useful if you only changed a couple of lines in your project as it makes the compilation proces faster.
 
 ### Closing stm32-debugger
 Once you finished your debugin session you can finish all the windows opened by this plugin with the following function.
 
-- M-x stm32-kill-gdb
+`stm32-kill-gdb
+
+This will kill the gdb process and the st-link or openocd proces depending on which do you chose to run
 
 After CubeMx project regeneration or adding new libraries or new sources you need to do M-x stm32-cmake-build
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,4 @@
+#STM32-Emacs
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
 
 Some functions for work with stm32 arm microcontrollers in EMACS.

--- a/board.cfg
+++ b/board.cfg
@@ -1,0 +1,33 @@
+# openocd requires a .cfg file to use the debuger/programer openocd can work with
+# many devices including stm but i have only tested stm microcontrollers
+# this file was made with the help of this post
+# https://www.shortn0tes.com/2017/10/the-most-detailed-guide-on-programming.html
+# my contribtion to this file is the freertos flag which enables gdb and as a
+# consequence emacsto view the thasks as threads
+source [find interface/stlink-v2.cfg]
+
+#set WORKAREASIZE 0x5000
+
+transport select "hla_swd"
+
+set CHIPNAME STM32F103CBTx
+
+# Enable debug when in low power modes
+set ENABLE_LOW_POWER 1
+
+# Stop Watchdog counters when halt
+set STOP_WATCHDOG 1
+
+# STlink Debug clock frequency
+set CLOCK_FREQ 4000
+
+# We do not connect RESET line to stlink, that's why reset is disabled.
+reset_config none
+
+source [find target/stm32f1x.cfg]
+# Enable FreeRTOS support
+$_TARGETNAME configure -rtos FreeRTOS
+
+#Enable Trace output in open OCD
+#Not tested yet
+#tpiu config external uart off 72000000 2000000


### PR DESCRIPTION
implementation of functions to use openocd instead of st-util, this is useful when you are working with RTOS projects, with this pull request you can debug those projects, but further documentation is required in the project of the user, I'm working on that part of the documentation.